### PR TITLE
Update coverage volume mapping in test Docker Compose file

### DIFF
--- a/booking_app/docker-compose.test.yml
+++ b/booking_app/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
       pytest
       "
     volumes:
-      - ./coverage.xml:/booking_app/coverage.xml
+      - ./coverage:/booking_app/coverage
     environment:
       - DJANGO_SETTINGS_MODULE=booking_app.settings_test
       - DEBUG=1


### PR DESCRIPTION
Changed the volume mount for coverage reports to map the entire coverage directory instead of a single file. This ensures all coverage-related files are accessible during test runs.